### PR TITLE
feat: add managed agents infrastructure

### DIFF
--- a/managed-agents/.env.example
+++ b/managed-agents/.env.example
@@ -1,0 +1,6 @@
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=github_pat_...
+
+# Lark webhook for session notifications (optional — skipped if empty)
+LARK_WEBHOOK_URL=https://open.larksuite.com/open-apis/bot/v2/hook/xxxxx
+LARK_WEBHOOK_SECRET=your-secret

--- a/managed-agents/.gitignore
+++ b/managed-agents/.gitignore
@@ -1,0 +1,4 @@
+.env
+.managed-agents.json
+node_modules/
+dist/

--- a/managed-agents/bun.lock
+++ b/managed-agents/bun.lock
@@ -1,0 +1,94 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "gomoku-managed-agents",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.87.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.87.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/managed-agents/cleanup.ts
+++ b/managed-agents/cleanup.ts
@@ -1,0 +1,149 @@
+/**
+ * CLEANUP — list and purge orphaned managed agent resources.
+ *
+ * Usage:
+ *   bun run cleanup              List all resources, show active vs orphaned
+ *   bun run cleanup -- --purge   Archive orphaned agents, delete orphaned envs/vaults
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { loadConfig } from "./lib/config.js";
+import type { FullConfig } from "./lib/config.js";
+
+const client = new Anthropic();
+const PURGE = process.argv.includes("--purge");
+
+function tryLoadConfig(): FullConfig | null {
+  try {
+    return loadConfig();
+  } catch {
+    return null;
+  }
+}
+
+function activeAgentIds(config: FullConfig): Set<string> {
+  return new Set([
+    config.shared_agent.id,
+    ...Object.values(config.agents).map((a) => a.id),
+  ]);
+}
+
+async function listAgents(config: FullConfig | null) {
+  const agents = await client.beta.agents.list();
+  const activeIds = config ? activeAgentIds(config) : new Set<string>();
+  const orphaned: string[] = [];
+
+  console.log("=== Agents ===\n");
+  for (const a of agents.data) {
+    const active = activeIds.has(a.id);
+    const archived = !!(a as any).archived_at;
+    const tag = archived ? "  [archived]" : active ? "  [active]" : "  [ORPHAN]";
+    console.log(`  ${a.id}  ${(a.name ?? "").padEnd(24)}  v${a.version}${tag}`);
+    if (!active && !archived) orphaned.push(a.id);
+  }
+  console.log(`\n  Total: ${agents.data.length}  |  Active: ${activeIds.size}  |  Orphaned: ${orphaned.length}`);
+  return orphaned;
+}
+
+async function listEnvironments(config: FullConfig | null) {
+  const envs = await client.beta.environments.list();
+  const activeId = config?.environment_id;
+  const orphaned: string[] = [];
+
+  console.log("\n=== Environments ===\n");
+  for (const e of envs.data) {
+    const active = e.id === activeId;
+    const archived = !!(e as any).archived_at;
+    const tag = archived ? "  [archived]" : active ? "  [active]" : "  [ORPHAN]";
+    console.log(`  ${e.id}  ${((e as any).name ?? "").padEnd(30)}${tag}`);
+    if (!active && !archived) orphaned.push(e.id);
+  }
+  console.log(`\n  Total: ${envs.data.length}  |  Active: ${activeId ? 1 : 0}  |  Orphaned: ${orphaned.length}`);
+  return orphaned;
+}
+
+async function listVaults(config: FullConfig | null) {
+  const vaults = await client.beta.vaults.list();
+  const activeId = config?.vault_id;
+  const orphaned: string[] = [];
+
+  console.log("\n=== Vaults ===\n");
+  for (const v of vaults.data) {
+    const active = v.id === activeId;
+    const archived = !!(v as any).archived_at;
+    const tag = archived ? "  [archived]" : active ? "  [active]" : "  [ORPHAN]";
+    console.log(`  ${v.id}  ${((v as any).display_name ?? "").padEnd(30)}${tag}`);
+    if (!active && !archived) orphaned.push(v.id);
+  }
+  console.log(`\n  Total: ${vaults.data.length}  |  Active: ${activeId ? 1 : 0}  |  Orphaned: ${orphaned.length}`);
+  return orphaned;
+}
+
+async function purge(
+  orphanedAgents: string[],
+  orphanedEnvs: string[],
+  orphanedVaults: string[],
+) {
+  const total = orphanedAgents.length + orphanedEnvs.length + orphanedVaults.length;
+  if (total === 0) {
+    console.log("\nNothing to purge.");
+    return;
+  }
+
+  console.log(`\n=== Purging ${total} orphaned resources ===\n`);
+
+  for (const id of orphanedAgents) {
+    try {
+      await client.beta.agents.archive(id);
+      console.log(`  x Agent archived: ${id}`);
+    } catch (e) {
+      console.log(`  - Agent ${id}: ${(e as Error).message}`);
+    }
+  }
+
+  for (const id of orphanedEnvs) {
+    try {
+      await client.beta.environments.delete(id);
+      console.log(`  x Environment deleted: ${id}`);
+    } catch (e) {
+      console.log(`  - Env ${id}: ${(e as Error).message}`);
+    }
+  }
+
+  for (const id of orphanedVaults) {
+    try {
+      await client.beta.vaults.delete(id);
+      console.log(`  x Vault deleted: ${id}`);
+    } catch (e) {
+      console.log(`  - Vault ${id}: ${(e as Error).message}`);
+    }
+  }
+
+  console.log("\nPurge complete.");
+}
+
+async function main() {
+  const config = tryLoadConfig();
+  if (!config) {
+    console.log("No .managed-agents.json found. Listing all resources as orphans.\n");
+  }
+
+  const orphanedAgents = await listAgents(config);
+  const orphanedEnvs = await listEnvironments(config);
+  const orphanedVaults = await listVaults(config);
+
+  const total = orphanedAgents.length + orphanedEnvs.length + orphanedVaults.length;
+
+  if (!PURGE && total > 0) {
+    console.log(`\nRun with --purge to clean up ${total} orphaned resources:`);
+    console.log("  bun run cleanup -- --purge");
+  } else if (PURGE) {
+    await purge(orphanedAgents, orphanedEnvs, orphanedVaults);
+  } else {
+    console.log("\nAll clean.");
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/lib/config.ts
+++ b/managed-agents/lib/config.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = path.join(__dirname, "..", ".managed-agents.json");
+
+export interface AgentRef {
+  id: string;
+  version: number;
+}
+
+export interface FullConfig {
+  environment_id: string;
+  vault_id: string;
+  skill_ids: { wtf: string };
+  shared_agent: AgentRef;
+  agents: {
+    event: AgentRef;
+    scheduled: AgentRef;
+    pr: AgentRef;
+    research: AgentRef;
+  };
+}
+
+/** What runSession needs — one agent + infra IDs */
+export interface SessionConfig {
+  environment_id: string;
+  vault_id: string;
+  agent_id: string;
+  agent_version: number;
+}
+
+export type PatternName = "event" | "scheduled" | "pr" | "research";
+
+/**
+ * Loads config and resolves which agent to use based on --shared flag.
+ * Returns a flat SessionConfig ready for runSession().
+ */
+export function resolveConfig(pattern: PatternName): SessionConfig {
+  const config = loadConfig();
+  const useShared = process.argv.includes("--shared");
+  const agent = useShared ? config.shared_agent : config.agents[pattern];
+
+  if (useShared) {
+    console.log("Mode: shared agent\n");
+  } else {
+    console.log(`Mode: dedicated ${pattern} agent\n`);
+  }
+
+  return {
+    environment_id: config.environment_id,
+    vault_id: config.vault_id,
+    agent_id: agent.id,
+    agent_version: agent.version,
+  };
+}
+
+export function loadConfig(): FullConfig {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    console.error("No .managed-agents.json found. Run: bun run setup");
+    process.exit(1);
+  }
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+export function saveConfig(config: FullConfig): void {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+}

--- a/managed-agents/lib/lark.ts
+++ b/managed-agents/lib/lark.ts
@@ -1,0 +1,37 @@
+import crypto from "crypto";
+
+/**
+ * Posts a message to a Lark webhook with HMAC-SHA256 signing.
+ * Silently skips if LARK_WEBHOOK_URL is not set.
+ */
+export async function postToLark(message: string): Promise<boolean> {
+  const url = process.env.LARK_WEBHOOK_URL;
+  const secret = process.env.LARK_WEBHOOK_SECRET;
+  if (!url) return false;
+
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const sign = secret
+    ? crypto.createHmac("sha256", `${ts}\n${secret}`).update("").digest("base64")
+    : undefined;
+
+  const body = JSON.stringify({
+    timestamp: ts,
+    ...(sign ? { sign } : {}),
+    msg_type: "text",
+    content: { text: message },
+  });
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+
+  if (!resp.ok) {
+    console.error(`  [lark] ${resp.status}: ${await resp.text()}`);
+    return false;
+  }
+
+  console.log("  [lark] Posted to Lark");
+  return true;
+}

--- a/managed-agents/lib/stream.ts
+++ b/managed-agents/lib/stream.ts
@@ -68,10 +68,32 @@ export async function runSession(
 
       case "agent.tool_use":
         console.log(`\n  [tool] ${(event as any).name ?? "built-in"}`);
+        // Auto-approve tools that need confirmation (always_ask policy)
+        if ((event as any).evaluated_permission === "ask") {
+          console.log(`  [auto-approve] ${(event as any).name}`);
+          await client.beta.sessions.events.send(session.id, {
+            events: [{
+              type: "user.tool_confirmation",
+              tool_use_id: event.id,
+              result: "allow",
+            } as any],
+          });
+        }
         break;
 
       case "agent.mcp_tool_use":
         console.log(`\n  [mcp]  ${(event as any).name ?? "mcp-tool"}`);
+        // Auto-approve MCP tools that need confirmation
+        if ((event as any).evaluated_permission === "ask") {
+          console.log(`  [auto-approve] ${(event as any).name}`);
+          await client.beta.sessions.events.send(session.id, {
+            events: [{
+              type: "user.tool_confirmation",
+              tool_use_id: event.id,
+              result: "allow",
+            } as any],
+          });
+        }
         break;
 
       case "agent.thinking":

--- a/managed-agents/lib/stream.ts
+++ b/managed-agents/lib/stream.ts
@@ -1,0 +1,118 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { SessionConfig } from "./config.js";
+import { postToLark } from "./lark.js";
+
+export interface SessionResult {
+  sessionId: string;
+  output: string;
+}
+
+/**
+ * Creates a session, sends a message, streams events, and posts output to Lark.
+ *
+ * Does NOT archive the session — caller is responsible for archiving
+ * after any post-processing (e.g. file downloads).
+ */
+export async function runSession(
+  client: Anthropic,
+  config: SessionConfig,
+  message: string,
+  title?: string,
+): Promise<SessionResult> {
+  // 1. Create session
+  const session = await client.beta.sessions.create({
+    agent: {
+      type: "agent",
+      id: config.agent_id,
+      version: config.agent_version,
+    },
+    environment_id: config.environment_id,
+    vault_ids: [config.vault_id],
+    title: title ?? "Managed Agent Session",
+    resources: [
+      {
+        type: "github_repository",
+        url: "https://github.com/tombelieber/gomoku",
+        authorization_token: process.env.GITHUB_TOKEN!,
+        checkout: { type: "branch", name: "main" },
+      },
+    ],
+  });
+  console.log(`Session: ${session.id} (${session.status})`);
+
+  // 2. Stream-first: open stream BEFORE sending
+  const stream = await client.beta.sessions.events.stream(session.id);
+
+  await client.beta.sessions.events.send(session.id, {
+    events: [
+      {
+        type: "user.message",
+        content: [{ type: "text", text: message }],
+      },
+    ],
+  });
+
+  // 3. Consume events with proper idle/terminated gate
+  const output: string[] = [];
+
+  for await (const event of stream) {
+    switch (event.type) {
+      case "agent.message":
+        for (const block of (event as any).content ?? []) {
+          if (block.type === "text") {
+            process.stdout.write(block.text);
+            output.push(block.text);
+          }
+        }
+        break;
+
+      case "agent.tool_use":
+        console.log(`\n  [tool] ${(event as any).name ?? "built-in"}`);
+        break;
+
+      case "agent.mcp_tool_use":
+        console.log(`\n  [mcp]  ${(event as any).name ?? "mcp-tool"}`);
+        break;
+
+      case "agent.thinking":
+        break;
+
+      case "session.error":
+        console.error("\n  [error]", event);
+        break;
+    }
+
+    if (event.type === "session.status_terminated") {
+      console.log("\n--- Session terminated ---");
+      break;
+    }
+    if (event.type === "session.status_idle") {
+      const stopReason = (event as any).stop_reason?.type;
+      if (stopReason === "requires_action") continue;
+      console.log("\n--- Session idle ---");
+      break;
+    }
+  }
+
+  // 4. Post output to Lark (if configured)
+  const text = output.join("");
+  if (text.length > 0) {
+    const larkMsg = title
+      ? `[${title}]\n\n${text.slice(0, 3000)}${text.length > 3000 ? "\n\n...(truncated)" : ""}`
+      : text.slice(0, 3000);
+    await postToLark(larkMsg).catch(() => {});
+  }
+
+  return { sessionId: session.id, output: text };
+}
+
+/** Archive a session after post-processing. Safe to call if already archived. */
+export async function archiveSession(client: Anthropic, sessionId: string): Promise<void> {
+  try {
+    await new Promise((r) => setTimeout(r, 500));
+    await client.beta.sessions.archive(sessionId);
+    console.log("Session archived.");
+  } catch {
+    // Already archived or not found — non-critical
+  }
+}

--- a/managed-agents/monitor.ts
+++ b/managed-agents/monitor.ts
@@ -1,0 +1,108 @@
+/**
+ * Monitor — inspect agents, sessions, and events from the CLI.
+ *
+ * Usage:
+ *   bun monitor.ts agents          # list all agents
+ *   bun monitor.ts sessions        # list all sessions
+ *   bun monitor.ts events <id>     # list events for a session
+ *   bun monitor.ts status <id>     # get session status + usage
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { loadConfig } from "./lib/config.js";
+
+const client = new Anthropic();
+const cmd = process.argv[2];
+const arg = process.argv[3];
+
+function loadConfig_safe() {
+  try {
+    return loadConfig();
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  switch (cmd) {
+    case "agents": {
+      const agents = await client.beta.agents.list();
+      console.log("=== Agents ===\n");
+      for (const a of agents.data) {
+        console.log(`  ${a.id}  ${a.name}  (v${a.version})`);
+      }
+      console.log(`\n  Total: ${agents.data.length}`);
+      break;
+    }
+
+    case "sessions": {
+      const sessions = await client.beta.sessions.list();
+      console.log("=== Sessions ===\n");
+      for (const s of sessions.data) {
+        console.log(
+          `  ${s.id}  ${s.status.padEnd(12)}  ${s.title ?? "(untitled)"}`,
+        );
+      }
+      console.log(`\n  Total: ${sessions.data.length}`);
+      break;
+    }
+
+    case "events": {
+      if (!arg) {
+        console.error("Usage: bun monitor.ts events <session_id>");
+        process.exit(1);
+      }
+      const events = await client.beta.sessions.events.list(arg);
+      console.log(`=== Events for ${arg} ===\n`);
+      for (const e of events.data) {
+        const time = e.processed_at
+          ? new Date(e.processed_at).toLocaleTimeString()
+          : "pending";
+        console.log(`  ${time.padEnd(12)}  ${e.type.padEnd(30)}  ${e.id}`);
+      }
+      console.log(`\n  Total: ${events.data.length}`);
+      break;
+    }
+
+    case "status": {
+      if (!arg) {
+        console.error("Usage: bun monitor.ts status <session_id>");
+        process.exit(1);
+      }
+      const session = await client.beta.sessions.retrieve(arg);
+      console.log(`=== Session ${arg} ===\n`);
+      console.log(`  Status:      ${session.status}`);
+      console.log(`  Title:       ${session.title ?? "(untitled)"}`);
+      console.log(`  Created:     ${session.created_at}`);
+      console.log(`  Updated:     ${session.updated_at}`);
+      if (session.usage) {
+        console.log(`  Input tkns:  ${(session.usage as any).input_tokens ?? "?"}`);
+        console.log(`  Output tkns: ${(session.usage as any).output_tokens ?? "?"}`);
+      }
+      break;
+    }
+
+    case "config": {
+      const config = loadConfig_safe();
+      if (!config) {
+        console.error("No .managed-agents.json found. Run: bun run setup");
+        process.exit(1);
+      }
+      console.log("=== Saved Config ===\n");
+      console.log(JSON.stringify(config, null, 2));
+      break;
+    }
+
+    default:
+      console.log(`Usage:
+  bun monitor.ts agents          List all agents
+  bun monitor.ts sessions        List all sessions
+  bun monitor.ts events <id>     List events for a session
+  bun monitor.ts status <id>     Get session status + usage
+  bun monitor.ts config          Show saved config`);
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/package.json
+++ b/managed-agents/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gomoku-managed-agents",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "setup": "bun setup.ts",
+    "pattern:event": "bun patterns/1-event-triggered.ts",
+    "pattern:scheduled": "bun patterns/2-scheduled.ts",
+    "pattern:pr": "bun patterns/3-fire-and-forget-pr.ts",
+    "pattern:research": "bun patterns/4-research-dashboard.ts",
+    "cleanup": "bun cleanup.ts",
+    "monitor": "bun monitor.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.87.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/managed-agents/patterns/1-event-triggered.ts
+++ b/managed-agents/patterns/1-event-triggered.ts
@@ -1,12 +1,15 @@
 /**
  * Pattern 1: Event-Triggered
  *
- * Simulates: GitHub webhook (PR push) → agent analyzes the PR → result posted to Lark
+ * Agent analyzes a PR and posts results to Lark.
  *
- * In production, a webhook handler would receive the GitHub event and call this.
- * Here we simulate it with a hardcoded PR description.
+ * Usage:
+ *   bun run pattern:event 4                          # review PR #4
+ *   bun run pattern:event "review PR #4 for i18n"    # freeform prompt
+ *   bun run pattern:event                            # uses default demo PR
  *
- * Usage: bun run pattern:event
+ * The agent has GitHub MCP tools — it fetches PR details, reads diffs, and
+ * analyzes the codebase automatically. Just give it a PR number or a question.
  */
 import Anthropic from "@anthropic-ai/sdk";
 import { resolveConfig } from "../lib/config.js";
@@ -15,32 +18,59 @@ import { runSession, archiveSession } from "../lib/stream.js";
 const client = new Anthropic();
 const config = resolveConfig("event");
 
-const simulatedPR = {
-  number: 42,
-  title: "feat: add AI difficulty selector",
-  author: "tombelieber",
-  branch: "feat/difficulty-selector",
-  files_changed: ["web/src/hooks/useGame.ts", "web/src/components/GameControls.tsx"],
-};
+// CLI arg: skip --shared and any flags starting with -
+const arg = process.argv.slice(2).find((a) => !a.startsWith("-"));
 
-const message = `
+function buildMessage(input: string | undefined): { message: string; title: string } {
+  // PR number
+  if (input && /^\d+$/.test(input)) {
+    return {
+      message: `
+Review PR #${input} on tombelieber/gomoku.
+
+Tasks:
+1. Use GitHub MCP tools to fetch the PR details and diff
+2. Read the affected files in the repo at /workspace/gomoku
+3. Assess code quality, correctness, and adherence to project conventions
+4. Write a concise review summary (3-5 bullet points)
+`.trim(),
+      title: `Event: PR #${input} Review`,
+    };
+  }
+
+  // Freeform prompt
+  if (input) {
+    return {
+      message: `${input}\n\nThe repo is at /workspace/gomoku. Use GitHub MCP tools if you need PR data.`,
+      title: `Event: ${input.slice(0, 50)}`,
+    };
+  }
+
+  // Default demo
+  return {
+    message: `
 A new PR was just opened on the Gomoku repo. Analyze it and post a summary.
 
 PR details:
-- #${simulatedPR.number}: "${simulatedPR.title}" by @${simulatedPR.author}
-- Branch: ${simulatedPR.branch}
-- Files changed: ${simulatedPR.files_changed.join(", ")}
+- #42: "feat: add AI difficulty selector" by @tombelieber
+- Branch: feat/difficulty-selector
+- Files changed: web/src/hooks/useGame.ts, web/src/components/GameControls.tsx
 
 Tasks:
 1. Read the repo structure to understand the codebase
 2. Analyze what these files do and assess the PR's impact
 3. Write a brief code review summary (3-5 bullet points)
-`.trim();
+`.trim(),
+    title: "Event: PR #42 Review (demo)",
+  };
+}
 
-console.log("=== Pattern 1: Event-Triggered (PR webhook → analysis → Lark) ===\n");
+const { message, title } = buildMessage(arg);
+
+console.log("=== Pattern 1: Event-Triggered (PR → analysis → Lark) ===\n");
 
 async function main() {
-  const { sessionId } = await runSession(client, config, message, "Event: PR #42 Review");
+  const { sessionId } = await runSession(client, config, message, title);
   await archiveSession(client, sessionId);
 }
 

--- a/managed-agents/patterns/1-event-triggered.ts
+++ b/managed-agents/patterns/1-event-triggered.ts
@@ -1,0 +1,50 @@
+/**
+ * Pattern 1: Event-Triggered
+ *
+ * Simulates: GitHub webhook (PR push) → agent analyzes the PR → result posted to Lark
+ *
+ * In production, a webhook handler would receive the GitHub event and call this.
+ * Here we simulate it with a hardcoded PR description.
+ *
+ * Usage: bun run pattern:event
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { resolveConfig } from "../lib/config.js";
+import { runSession, archiveSession } from "../lib/stream.js";
+
+const client = new Anthropic();
+const config = resolveConfig("event");
+
+const simulatedPR = {
+  number: 42,
+  title: "feat: add AI difficulty selector",
+  author: "tombelieber",
+  branch: "feat/difficulty-selector",
+  files_changed: ["web/src/hooks/useGame.ts", "web/src/components/GameControls.tsx"],
+};
+
+const message = `
+A new PR was just opened on the Gomoku repo. Analyze it and post a summary.
+
+PR details:
+- #${simulatedPR.number}: "${simulatedPR.title}" by @${simulatedPR.author}
+- Branch: ${simulatedPR.branch}
+- Files changed: ${simulatedPR.files_changed.join(", ")}
+
+Tasks:
+1. Read the repo structure to understand the codebase
+2. Analyze what these files do and assess the PR's impact
+3. Write a brief code review summary (3-5 bullet points)
+`.trim();
+
+console.log("=== Pattern 1: Event-Triggered (PR webhook → analysis → Lark) ===\n");
+
+async function main() {
+  const { sessionId } = await runSession(client, config, message, "Event: PR #42 Review");
+  await archiveSession(client, sessionId);
+}
+
+main().catch((err) => {
+  console.error("Failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/patterns/1-event-triggered.ts
+++ b/managed-agents/patterns/1-event-triggered.ts
@@ -29,10 +29,14 @@ function buildMessage(input: string | undefined): { message: string; title: stri
 Review PR #${input} on tombelieber/gomoku.
 
 Tasks:
-1. Use GitHub MCP tools to fetch the PR details and diff
-2. Read the affected files in the repo at /workspace/gomoku
+1. The repo is at /workspace/gomoku. Use bash to fetch PR info:
+   - cd /workspace/gomoku && git fetch origin 'pull/${input}/head:pr-${input}' && git diff main...pr-${input}
+   - Or: curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/tombelieber/gomoku/pulls/${input}
+2. Read the affected files to understand context
 3. Assess code quality, correctness, and adherence to project conventions
 4. Write a concise review summary (3-5 bullet points)
+
+Do NOT use GitHub MCP tools for reading — use bash and git instead.
 `.trim(),
       title: `Event: PR #${input} Review`,
     };

--- a/managed-agents/patterns/2-scheduled.ts
+++ b/managed-agents/patterns/2-scheduled.ts
@@ -1,0 +1,52 @@
+/**
+ * Pattern 2: Scheduled (Cron)
+ *
+ * Simulates: Daily cron → agent generates a repo health report → result posted to Lark
+ *
+ * In production, a cron job (GitHub Actions, AWS EventBridge, etc.) would trigger this.
+ * Here we run it manually.
+ *
+ * Usage: bun run pattern:scheduled
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { resolveConfig } from "../lib/config.js";
+import { runSession, archiveSession } from "../lib/stream.js";
+
+const client = new Anthropic();
+const config = resolveConfig("scheduled");
+
+const today = new Date().toISOString().split("T")[0];
+
+const message = `
+Generate a daily repo health report for ${today}.
+
+Tasks:
+1. Read the repo at /workspace/gomoku
+2. Check the git log for recent commits (last 7 days)
+3. Look at open issues or TODOs in the codebase (grep for TODO, FIXME, HACK)
+4. Check the package.json for outdated or concerning dependencies
+5. Summarize the i18n coverage (how many languages, any missing keys?)
+
+Format the report as:
+## Gomoku Daily Report — ${today}
+### Recent Activity
+(last 5 commits)
+### Code Health
+(TODO/FIXME count, any concerns)
+### i18n Status
+(languages supported, coverage)
+### Recommendations
+(1-3 actionable items)
+`.trim();
+
+console.log("=== Pattern 2: Scheduled (Daily repo health report) ===\n");
+
+async function main() {
+  const { sessionId } = await runSession(client, config, message, `Daily Report ${today}`);
+  await archiveSession(client, sessionId);
+}
+
+main().catch((err) => {
+  console.error("Failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/patterns/2-scheduled.ts
+++ b/managed-agents/patterns/2-scheduled.ts
@@ -1,12 +1,11 @@
 /**
  * Pattern 2: Scheduled (Cron)
  *
- * Simulates: Daily cron → agent generates a repo health report → result posted to Lark
+ * Agent generates a repo health report and posts to Lark.
  *
- * In production, a cron job (GitHub Actions, AWS EventBridge, etc.) would trigger this.
- * Here we run it manually.
- *
- * Usage: bun run pattern:scheduled
+ * Usage:
+ *   bun run pattern:scheduled                              # default health report
+ *   bun run pattern:scheduled "focus on dependency audit"   # custom focus
  */
 import Anthropic from "@anthropic-ai/sdk";
 import { resolveConfig } from "../lib/config.js";
@@ -16,8 +15,9 @@ const client = new Anthropic();
 const config = resolveConfig("scheduled");
 
 const today = new Date().toISOString().split("T")[0];
+const arg = process.argv.slice(2).find((a) => !a.startsWith("-"));
 
-const message = `
+const baseMessage = `
 Generate a daily repo health report for ${today}.
 
 Tasks:
@@ -38,6 +38,8 @@ Format the report as:
 ### Recommendations
 (1-3 actionable items)
 `.trim();
+
+const message = arg ? `${baseMessage}\n\nAdditional focus: ${arg}` : baseMessage;
 
 console.log("=== Pattern 2: Scheduled (Daily repo health report) ===\n");
 

--- a/managed-agents/patterns/3-fire-and-forget-pr.ts
+++ b/managed-agents/patterns/3-fire-and-forget-pr.ts
@@ -1,0 +1,49 @@
+/**
+ * Pattern 3: Fire-and-Forget PR
+ *
+ * Human provides a task → agent makes code changes → pushes branch → creates PR
+ *
+ * The agent uses bash+git for the branch/push and GitHub MCP for PR creation.
+ * The github_repository resource mounts the repo with write access.
+ *
+ * Usage: bun run pattern:pr
+ *
+ * NOTE: This will actually push a branch and create a PR on your repo.
+ * Make sure GITHUB_TOKEN has Contents:Write + PullRequests:Write permissions.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { resolveConfig } from "../lib/config.js";
+import { runSession, archiveSession } from "../lib/stream.js";
+
+const client = new Anthropic();
+const config = resolveConfig("pr");
+
+const task = `
+Add a "last updated" timestamp display to the game UI.
+
+Requirements:
+1. In /workspace/gomoku, create a new branch: agent/add-timestamp
+2. Add a simple timestamp that shows when the game state was last modified
+3. The timestamp should be stored in the game Zustand store (useGame.ts)
+4. Display it in the UI somewhere unobtrusive
+5. Follow the existing i18n pattern — add keys to the Translation interface
+   and ALL 11 locale files in web/src/i18n/translations/
+6. Commit the changes with message "feat: add last-updated timestamp to game UI"
+7. Push the branch
+8. Create a PR using the GitHub MCP tool targeting main
+
+IMPORTANT: Follow the existing code patterns. Check how other state is managed
+in useGame.ts before adding new state. Use inline styles (no Tailwind classes).
+`.trim();
+
+console.log("=== Pattern 3: Fire-and-Forget PR (task → code → push → PR) ===\n");
+
+async function main() {
+  const { sessionId } = await runSession(client, config, task, "PR: Add timestamp");
+  await archiveSession(client, sessionId);
+}
+
+main().catch((err) => {
+  console.error("Failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/patterns/4-research-dashboard.ts
+++ b/managed-agents/patterns/4-research-dashboard.ts
@@ -1,0 +1,82 @@
+/**
+ * Pattern 4: Research + Dashboard
+ *
+ * Human provides a topic → agent researches using web_search + codebase analysis
+ * → generates an HTML report saved to /mnt/session/outputs/
+ *
+ * The output HTML file is downloaded after the session completes.
+ *
+ * Usage: bun run pattern:research
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import fs from "fs";
+import { resolveConfig } from "../lib/config.js";
+import { runSession, archiveSession } from "../lib/stream.js";
+
+const client = new Anthropic();
+const config = resolveConfig("research");
+
+const topic = `
+Research the competitive landscape for browser-based gomoku/five-in-a-row games.
+
+Tasks:
+1. Search the web for popular online gomoku games and AI implementations
+2. Analyze the /workspace/gomoku codebase to understand our current features
+3. Compare our implementation against what competitors offer:
+   - AI difficulty levels and algorithms used
+   - Multiplayer support
+   - Mobile responsiveness
+   - i18n support
+   - UI/UX quality
+4. Generate a competitive analysis HTML dashboard and save it to
+   /mnt/session/outputs/competitive-analysis.html
+
+The HTML should be self-contained (inline CSS, no external deps) with:
+- A summary table comparing features across competitors
+- Our strengths and gaps highlighted
+- 3-5 actionable recommendations for improvement
+- Clean, modern styling (dark theme preferred)
+
+Make the report visually polished — this is for a product review meeting.
+`.trim();
+
+console.log("=== Pattern 4: Research + Dashboard (topic → web search → HTML report) ===\n");
+
+async function main() {
+  const { sessionId } = await runSession(client, config, topic, "Research: Competitive Analysis");
+
+  // Download output files from the session
+  console.log("\nChecking for output files...");
+
+  // Brief delay for file indexing (~1-3s lag after session goes idle)
+  await new Promise((r) => setTimeout(r, 3000));
+
+  try {
+    // scope: sessionId returns ONLY files written to /mnt/session/outputs/
+    const files = await client.beta.files.list({ scope: sessionId } as any);
+    await fs.promises.mkdir("./outputs", { recursive: true });
+
+    for (const f of files.data) {
+      const resp = await client.beta.files.download(f.id);
+      const buffer = Buffer.from(await resp.arrayBuffer());
+      const safeName = f.filename ?? `output-${f.id}`;
+      const outputPath = `./outputs/${safeName}`;
+      await fs.promises.writeFile(outputPath, buffer);
+      console.log(`Downloaded: ${outputPath} (${buffer.length} bytes)`);
+    }
+
+    if (files.data.length === 0) {
+      console.log("No output files found — the report may be in stdout above.");
+      console.log(`Session ID for manual check: ${sessionId}`);
+    }
+  } catch (err) {
+    console.log("Could not download outputs:", (err as Error).message);
+  }
+
+  await archiveSession(client, sessionId);
+}
+
+main().catch((err) => {
+  console.error("Failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/setup.ts
+++ b/managed-agents/setup.ts
@@ -40,8 +40,15 @@ const MCP_SERVERS = [
 ];
 
 const ALL_TOOLS = [
-  { type: "agent_toolset_20260401" as const, default_config: { enabled: true } },
-  { type: "mcp_toolset" as const, mcp_server_name: "github" },
+  {
+    type: "agent_toolset_20260401" as const,
+    default_config: { enabled: true, permission_policy: { type: "always_allow" } },
+  },
+  {
+    type: "mcp_toolset" as const,
+    mcp_server_name: "github",
+    default_config: { permission_policy: { type: "always_allow" } },
+  },
 ];
 
 type SkillRef =

--- a/managed-agents/setup.ts
+++ b/managed-agents/setup.ts
@@ -1,0 +1,309 @@
+/**
+ * SETUP — idempotent. Creates or updates managed agent infrastructure.
+ *
+ * Modes:
+ *   bun run setup              If config exists → update agents in-place
+ *                               If no config → create everything fresh
+ *   bun run setup -- --fresh   Archive old agents, create everything fresh
+ *
+ * Creates/updates:
+ *   1. Environment (sandbox config)
+ *   2. Vault + credentials (GitHub MCP + Slack MCP auth)
+ *   3. 5 agents (1 shared + 4 dedicated)
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { toFile } from "@anthropic-ai/sdk";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { loadConfig, saveConfig } from "./lib/config.js";
+import type { AgentRef, FullConfig } from "./lib/config.js";
+
+const client = new Anthropic();
+const FRESH = process.argv.includes("--fresh");
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`Missing env var: ${name}. See .env.example`);
+    process.exit(1);
+  }
+  return val;
+}
+
+// ── Model & infra constants ──
+
+const MODEL = "claude-haiku-4-5";
+
+const MCP_SERVERS = [
+  { type: "url" as const, name: "github", url: "https://api.githubcopilot.com/mcp/" },
+];
+
+const ALL_TOOLS = [
+  { type: "agent_toolset_20260401" as const, default_config: { enabled: true } },
+  { type: "mcp_toolset" as const, mcp_server_name: "github" },
+];
+
+type SkillRef =
+  | { type: "anthropic"; skill_id: string }
+  | { type: "custom"; skill_id: string; version: string };
+
+// ── Agent definitions (single source of truth) ──
+
+function agentDefs(wtfSkillId: string) {
+  return {
+    shared: {
+      name: "Gomoku Shared Agent",
+      system: [
+        "You are a research and development agent for the Gomoku project —",
+        "an AI-powered gomoku game built with React 19, TypeScript, Zustand,",
+        "and a Rust/WASM engine. You help with code analysis, feature research,",
+        "PR creation, automated reporting, and codebase exploration.",
+        "The repo is mounted at /workspace/gomoku.",
+      ].join(" "),
+      tools: ALL_TOOLS,
+      skills: [
+        { type: "anthropic" as const, skill_id: "pdf" },
+        { type: "anthropic" as const, skill_id: "xlsx" },
+        { type: "custom" as const, skill_id: wtfSkillId, version: "latest" },
+      ],
+    },
+    event: {
+      name: "Gomoku PR Reviewer",
+      system: [
+        "You are a code review specialist for the Gomoku project.",
+        "When given a PR description, you analyze the affected files,",
+        "assess code quality and impact, and produce a concise review summary.",
+        "Post results to Slack when available. The repo is at /workspace/gomoku.",
+      ].join(" "),
+      tools: ALL_TOOLS,
+      skills: undefined as SkillRef[] | undefined,
+    },
+    scheduled: {
+      name: "Gomoku Reporter",
+      system: [
+        "You are a reporting agent for the Gomoku project.",
+        "You generate structured health reports: recent commits, code quality",
+        "(TODOs/FIXMEs), dependency status, and i18n coverage.",
+        "Format reports in clean markdown. Post to Slack when available.",
+        "The repo is at /workspace/gomoku.",
+      ].join(" "),
+      tools: ALL_TOOLS,
+      skills: [
+        { type: "anthropic" as const, skill_id: "xlsx" },
+        { type: "custom" as const, skill_id: wtfSkillId, version: "latest" },
+      ],
+    },
+    pr: {
+      name: "Gomoku Coder",
+      system: [
+        "You are a coding agent for the Gomoku project.",
+        "Given a task, you implement changes following existing patterns:",
+        "inline styles (no Tailwind), Zustand stores, i18n via all 11 locale files.",
+        "You create branches, commit, push, and open PRs via GitHub MCP.",
+        "The repo is at /workspace/gomoku.",
+      ].join(" "),
+      tools: ALL_TOOLS,
+      skills: undefined as SkillRef[] | undefined,
+    },
+    research: {
+      name: "Gomoku Researcher",
+      system: [
+        "You are a research analyst for the Gomoku project.",
+        "You investigate topics using web search, analyze the codebase,",
+        "and produce polished HTML reports saved to /mnt/session/outputs/.",
+        "Reports should be self-contained (inline CSS), visually clean,",
+        "and actionable. The repo is at /workspace/gomoku.",
+      ].join(" "),
+      tools: ALL_TOOLS,
+      skills: [{ type: "anthropic" as const, skill_id: "pdf" }],
+    },
+  };
+}
+
+// ── Helpers ──
+
+async function createAgent(
+  def: { name: string; system: string; tools: typeof ALL_TOOLS; skills?: SkillRef[] },
+): Promise<AgentRef> {
+  const agent = await client.beta.agents.create({
+    name: def.name,
+    model: MODEL,
+    system: def.system,
+    mcp_servers: MCP_SERVERS,
+    tools: def.tools,
+    ...(def.skills?.length ? { skills: def.skills } : {}),
+  });
+  console.log(`  + ${def.name}: ${agent.id} (v${agent.version})`);
+  return { id: agent.id, version: agent.version };
+}
+
+async function updateAgent(
+  existing: AgentRef,
+  def: { name: string; system: string; tools: typeof ALL_TOOLS; skills?: SkillRef[] },
+): Promise<AgentRef> {
+  const agent = await client.beta.agents.update(existing.id, {
+    version: existing.version,
+    name: def.name,
+    model: MODEL,
+    system: def.system,
+    mcp_servers: MCP_SERVERS,
+    tools: def.tools,
+    ...(def.skills?.length ? { skills: def.skills } : {}),
+  });
+  const oldV = existing.version;
+  const newV = agent.version;
+  const changed = oldV !== newV ? `v${oldV} -> v${newV}` : `v${newV} (unchanged)`;
+  console.log(`  ~ ${def.name}: ${agent.id} (${changed})`);
+  return { id: agent.id, version: agent.version };
+}
+
+async function uploadSkill(commandPath: string, displayTitle: string): Promise<string> {
+  const fullPath = path.join(os.homedir(), commandPath);
+  if (!fs.existsSync(fullPath)) {
+    console.error(`  Skill source not found: ${fullPath}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(fullPath, "utf-8");
+  const folderName = path.basename(commandPath, ".md");
+  const skillFile = await toFile(
+    Buffer.from(content),
+    `${folderName}/SKILL.md`,
+    { type: "text/markdown" },
+  );
+
+  const skill = await client.beta.skills.create({
+    display_title: displayTitle,
+    files: [skillFile],
+  });
+
+  console.log(`  + Skill "${displayTitle}": ${skill.id}`);
+  return skill.id;
+}
+
+function tryLoadConfig(): FullConfig | null {
+  try {
+    return loadConfig();
+  } catch {
+    return null;
+  }
+}
+
+// ── Update path (config exists, no --fresh) ──
+
+async function updateExisting(config: FullConfig) {
+  console.log(`Updating agents to model: ${MODEL}\n`);
+
+  const wtfSkillId = config.skill_ids.wtf;
+  const defs = agentDefs(wtfSkillId);
+
+  console.log("Updating agents...");
+  const shared = await updateAgent(config.shared_agent, defs.shared);
+  const event = await updateAgent(config.agents.event, defs.event);
+  const scheduled = await updateAgent(config.agents.scheduled, defs.scheduled);
+  const pr = await updateAgent(config.agents.pr, defs.pr);
+  const research = await updateAgent(config.agents.research, defs.research);
+
+  saveConfig({
+    ...config,
+    shared_agent: shared,
+    agents: { event, scheduled, pr, research },
+  });
+
+  console.log("\nUpdate complete! New versions saved to .managed-agents.json");
+}
+
+// ── Fresh create path ──
+
+async function createFresh(oldConfig: FullConfig | null) {
+  const githubToken = requireEnv("GITHUB_TOKEN");
+
+  // Archive old agents if --fresh
+  if (oldConfig && FRESH) {
+    console.log("Archiving old agents...");
+    const oldAgents = [
+      oldConfig.shared_agent,
+      ...Object.values(oldConfig.agents),
+    ];
+    for (const a of oldAgents) {
+      try {
+        await client.beta.agents.archive(a.id);
+        console.log(`  x Archived ${a.id}`);
+      } catch {
+        console.log(`  - ${a.id} (already archived or not found)`);
+      }
+    }
+    console.log();
+  }
+
+  // 1. Environment
+  console.log("1/4  Creating environment...");
+  const environment = await client.beta.environments.create({
+    name: `gomoku-env-${Date.now()}`,
+    config: {
+      type: "cloud",
+      networking: { type: "unrestricted" },
+    },
+  });
+  console.log(`     env_id: ${environment.id}`);
+
+  // 2. Vault + credentials
+  console.log("2/4  Creating vault + credentials...");
+  const vault = await client.beta.vaults.create({
+    display_name: `gomoku-vault-${Date.now()}`,
+  });
+
+  await client.beta.vaults.credentials.create(vault.id, {
+    display_name: "GitHub MCP",
+    auth: {
+      type: "mcp_oauth",
+      mcp_server_url: "https://api.githubcopilot.com/mcp/",
+      access_token: githubToken,
+    },
+  });
+  console.log(`     vault_id: ${vault.id}`);
+
+  // 3. Custom skills
+  console.log("3/4  Uploading custom skills...");
+  const wtfSkillId = await uploadSkill(".claude/commands/wtf.md", "WTF Status Report");
+
+  // 4. Agents
+  console.log("4/4  Creating agents...");
+  const defs = agentDefs(wtfSkillId);
+  const shared = await createAgent(defs.shared);
+  const event = await createAgent(defs.event);
+  const scheduled = await createAgent(defs.scheduled);
+  const pr = await createAgent(defs.pr);
+  const research = await createAgent(defs.research);
+
+  saveConfig({
+    environment_id: environment.id,
+    vault_id: vault.id,
+    skill_ids: { wtf: wtfSkillId },
+    shared_agent: shared,
+    agents: { event, scheduled, pr, research },
+  });
+
+  console.log("\nSetup complete! IDs saved to .managed-agents.json");
+  console.log("\nRun any pattern:");
+  console.log("  bun run pattern:research              # dedicated agent");
+  console.log("  bun run pattern:research -- --shared   # shared agent");
+}
+
+// ── Main ──
+
+async function setup() {
+  const existing = tryLoadConfig();
+
+  if (existing && !FRESH) {
+    await updateExisting(existing);
+  } else {
+    await createFresh(existing);
+  }
+}
+
+setup().catch((err) => {
+  console.error("Setup failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/managed-agents/tsconfig.json
+++ b/managed-agents/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts", "lib/**/*.ts", "patterns/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add Claude Managed Agents setup for 4 automated repo task patterns: event-triggered PR review, scheduled health reports, fire-and-forget PR creation, and research dashboards
- Idempotent setup script — `bun run setup` updates agents in-place, `--fresh` for full recreate
- Cleanup script (`bun run cleanup --purge`) to list and archive orphaned agents/envs/vaults
- Client-side Lark webhook notifications for all session outputs (replaces agent-side Slack MCP)
- CLI args for patterns: `bun run pattern:event 4`, `bun run pattern:scheduled "focus on deps"`

## Test plan
- [x] `bun run setup` — updates existing agents without creating orphans
- [x] `bun run cleanup` — lists all resources, shows active vs orphaned
- [x] `bun run pattern:scheduled` — runs health report, posts to Lark
- [x] `bun run pattern:research` — runs competitive analysis, downloads HTML report
- [x] `bun run pattern:event 4` — reviews real PR #4, posts to Lark (2nd run after MCP fix)
- [ ] `bun run pattern:pr` — creates actual PR on repo (destructive — skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)